### PR TITLE
Add inputFormats to JS Transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Transform a file asynchronously. If a callback is provided, it is called as `cal
 ### `.inputFormats`
 
 ```js
-var formats = transformer.inputFormats();
+var formats = transformer.inputFormats;
 => ['md', 'markdown']
 ```
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ _requires the underlying transform to implement `.renderFileAsync`, `.renderFile
 
 Transform a file asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 
+### `.inputFormats`
+
+```js
+var formats = transformer.inputFormats();
+=> ['md', 'markdown']
+```
+
+Returns an array of strings representing potential input formats for the transform. If not provided directly by the transform, results in an array containing the name of the transform.
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -94,6 +94,7 @@ function Transformer(tr) {
   this._tr = tr;
   this.name = this._tr.name;
   this.outputFormat = this._tr.outputFormat;
+  this.inputFormats = this._tr.inputFormats || [this.name];
 }
 
 var fallbacks = {
@@ -324,11 +325,4 @@ Transformer.prototype.renderFileAsync = function (filename, options, locals, cb)
       return this.renderAsync(str, options, locals);
     }.bind(this)), cb);
   }
-};
-
-/**
- * inputFormats
- */
-Transformer.prototype.inputFormats = function() {
-  return this._tr.inputFormats || [this._tr.name];
 };

--- a/index.js
+++ b/index.js
@@ -325,3 +325,10 @@ Transformer.prototype.renderFileAsync = function (filename, options, locals, cb)
     }.bind(this)), cb);
   }
 };
+
+/**
+ * inputFormats
+ */
+Transformer.prototype.inputFormats = function() {
+  return this._tr.inputFormats || [this._tr.name];
+};

--- a/test/index.js
+++ b/test/index.js
@@ -38,4 +38,4 @@ require('./compile-file-client');
 require('./compile-file-client-async');
 require('./render');
 require('./render-async');
-require('./input-format');
+require('./input-formats');

--- a/test/index.js
+++ b/test/index.js
@@ -38,3 +38,4 @@ require('./compile-file-client');
 require('./compile-file-client-async');
 require('./render');
 require('./render-async');
+require('./input-format');

--- a/test/input-format.js
+++ b/test/input-format.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var assert = require('assert');
+var test = require('./test');
+var createTransformer = require('../');
+
+test('inputFormats - with tr.inputFormats', function (override) {
+  var tr = createTransformer({
+    name: 'test',
+    outputFormat: 'html',
+    inputFormats: [
+      'html',
+      'htm'
+    ],
+    render: function (str, options) {
+      return str;
+    }
+  });
+  assert.deepEqual(tr.inputFormats(), ['html', 'htm']);
+});
+
+test('inputFormats - without tr.inputFormats', function (override) {
+  var tr = createTransformer({
+    name: 'test',
+    outputFormat: 'html',
+    render: function (str, options) {
+      return str;
+    }
+  });
+  assert.deepEqual(tr.inputFormats(), ['test']);
+});

--- a/test/input-formats.js
+++ b/test/input-formats.js
@@ -16,7 +16,7 @@ test('inputFormats - with tr.inputFormats', function (override) {
       return str;
     }
   });
-  assert.deepEqual(tr.inputFormats(), ['html', 'htm']);
+  assert.deepEqual(tr.inputFormats, ['html', 'htm']);
 });
 
 test('inputFormats - without tr.inputFormats', function (override) {
@@ -27,5 +27,5 @@ test('inputFormats - without tr.inputFormats', function (override) {
       return str;
     }
   });
-  assert.deepEqual(tr.inputFormats(), ['test']);
+  assert.deepEqual(tr.inputFormats, ['test']);
 });


### PR DESCRIPTION
First pass at #5... See the [inputFormats documentation](https://github.com/jstransformers/jstransformer/blob/inputformat/README.md#inputformats).

> Returns an array of strings representing potential input formats for the transform. If not provided directly by the transform, results in an array containing the name of the transform.