### PR TITLE
Rewrite output format test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -14,11 +14,6 @@ test('constructor - throws if `tr` does not have a name', function () {
     createTransformer({});
   }, /Transformer must have a name/);
 });
-test('constructor - throws if `tr` does not have an output format', function () {
-  assert.throws(function () {
-    createTransformer({name: 'test'});
-  }, /Transformer must have an output format/);
-});
 test('constructor - throws if `tr` does not have any methods', function () {
   assert.throws(function () {
     createTransformer({name: 'test', outputFormat: 'html'});
@@ -39,3 +34,4 @@ require('./compile-file-client-async');
 require('./render');
 require('./render-async');
 require('./input-formats');
+require('./output-format');

--- a/test/output-format.js
+++ b/test/output-format.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var assert = require('assert');
+var test = require('./test');
+var createTransformer = require('../');
+
+test('outputFormat - preserves tr.outputFormat', function () {
+  var tr = createTransformer({
+    name: 'test',
+    outputFormat: 'css',
+    render: function (str, options) {
+      return str;
+    }
+  });
+  assert.equal(tr.outputFormat, 'css');
+});
+test('outputFormat - throws without tr.outputFormat', function () {
+  assert.throws(function () {
+    createTransformer({
+      name: 'test',
+      render: function (str, options) {
+        return str;
+      }
+    });
+  }, /Transformer must have an output format/);
+});


### PR DESCRIPTION
This way it is symmetrical to the inputFormats test, and tests if the `outputFormat` property is preserved.