### PR TITLE
Better test category output

### DIFF
--- a/test/compile-async.js
+++ b/test/compile-async.js
@@ -5,7 +5,9 @@ var Promise = require('promise');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compileAsync - with tr.compileAsync(str, options) => Promise(fn)', function (override) {
+test('compileAsync', function () {
+
+test('with tr.compileAsync(str, options) => Promise(fn)', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var cbSentinel = {};
@@ -26,7 +28,7 @@ test('compileAsync - with tr.compileAsync(str, options) => Promise(fn)', functio
   });
   assert(tr.compileAsync('example input', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('compileAsync - with tr.compile(str, options) => fn', function () {
+test('with tr.compile(str, options) => fn', function () {
   var sentinel = {};
   var fnSentinel = function (locals) {};
   var tr = createTransformer({
@@ -42,7 +44,7 @@ test('compileAsync - with tr.compile(str, options) => fn', function () {
     assert(out.fn === fnSentinel);
   });
 });
-test('compileAsync - with tr.render(str, options, locals) => output', function () {
+test('with tr.render(str, options, locals) => output', function () {
   var sentinel = {};
   var localsSentinel = {};
   var tr = createTransformer({
@@ -59,7 +61,7 @@ test('compileAsync - with tr.render(str, options, locals) => output', function (
     assert(out.fn(localsSentinel) === 'example output');
   });
 });
-test('compileAsync - without tr.compile, tr.compileAsync, or tr.render', function () {
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -71,4 +73,6 @@ test('compileAsync - without tr.compile, tr.compileAsync, or tr.render', functio
   }, function (err) {
     if (!(/does not support compiling plain strings/.test(err.message))) throw err;
   });
+});
+
 });

--- a/test/compile-client-async.js
+++ b/test/compile-client-async.js
@@ -5,7 +5,9 @@ var Promise = require('promise');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compileClientAsync - with tr.compileClientAsync(src, options) => Promise(str)', function (override) {
+test('compileClientAsync', function () {
+
+test('with tr.compileClientAsync(src, options) => Promise(str)', function (override) {
   var sentinel = {};
   var bodySentinel = {};
   var cbSentinel = {};
@@ -26,7 +28,7 @@ test('compileClientAsync - with tr.compileClientAsync(src, options) => Promise(s
   });
   assert(tr.compileClientAsync('example input', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('compileClientAsync - with tr.compileClient(src, options) => fn', function (override) {
+test('with tr.compileClient(src, options) => fn', function (override) {
   var sentinel = {};
   var bodySentinel = {};
   var cbSentinel = {};
@@ -47,7 +49,7 @@ test('compileClientAsync - with tr.compileClient(src, options) => fn', function 
   });
   assert(tr.compileClientAsync('example input', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('compileClientAsync - without tr.compileClient', function () {
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -75,4 +77,6 @@ test('compileClientAsync - without tr.compileClient', function () {
     }
   });
   return Promise.all([a, b]);
+});
+
 });

--- a/test/compile-client.js
+++ b/test/compile-client.js
@@ -4,7 +4,9 @@ var assert = require('assert');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compileClient - with tr.compileClient(src, options) => str', function (override) {
+test('compileClient', function () {
+
+test('with tr.compileClient(src, options) => str', function (override) {
   var sentinel = {};
   var localSentinel = {};
   var fnSentinel = {};
@@ -24,7 +26,7 @@ test('compileClient - with tr.compileClient(src, options) => str', function (ove
   });
   assert(tr.compileClient('example input', sentinel) === normalizedSentinel);
 });
-test('compileClient - without tr.compileClient', function () {
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -52,4 +54,6 @@ test('compileClient - without tr.compileClient', function () {
   assert.throws(function () {
     tr.compileClient('example input', {});
   }, /does not support compiling for the client/);
+});
+
 });

--- a/test/compile-file-async.js
+++ b/test/compile-file-async.js
@@ -5,7 +5,9 @@ var Promise = require('promise');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compileFileAsync - with tr.compileFileAsync(src, options) => Promise(fn)', function (override) {
+test('compileFileAsync', function () {
+
+test('with tr.compileFileAsync(src, options) => Promise(fn)', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var cbSentinel = {};
@@ -26,7 +28,7 @@ test('compileFileAsync - with tr.compileFileAsync(src, options) => Promise(fn)',
   });
   assert(tr.compileFileAsync('example input', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('compileFileAsync - with tr.compileFile(src, options) => fn', function () {
+test('with tr.compileFile(src, options) => fn', function () {
   var sentinel = {};
   var fnSentinel = function (locals) {};
   var tr = createTransformer({
@@ -42,7 +44,7 @@ test('compileFileAsync - with tr.compileFile(src, options) => fn', function () {
     assert(out.fn === fnSentinel);
   });
 });
-test('compileFileAsync - with tr.compileAsync(src, options) => Promise(fn)', function (override) {
+test('with tr.compileAsync(src, options) => Promise(fn)', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var cbSentinel = {};
@@ -68,7 +70,7 @@ test('compileFileAsync - with tr.compileAsync(src, options) => Promise(fn)', fun
   });
   assert(tr.compileFileAsync('example-input.txt', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('compileFileAsync - with tr.compile(src, options) => fn', function (override) {
+test('with tr.compile(src, options) => fn', function (override) {
   var sentinel = {};
   var fnSentinel = function (locals) {};
   override('readFile', function (filename, encoding) {
@@ -89,7 +91,7 @@ test('compileFileAsync - with tr.compile(src, options) => fn', function (overrid
     assert(out.fn === fnSentinel);
   });
 });
-test('compileFileAsync - with tr.renderFile(file, options, locals) => output', function () {
+test('with tr.renderFile(file, options, locals) => output', function () {
   var sentinel = {};
   var localsSentinel = {};
   var tr = createTransformer({
@@ -106,7 +108,7 @@ test('compileFileAsync - with tr.renderFile(file, options, locals) => output', f
     assert(out.fn(localsSentinel) === 'example output');
   });
 });
-test('compileFileAsync - with tr.render(src, options, locals) => output', function (override) {
+test('with tr.render(src, options, locals) => output', function (override) {
   var sentinel = {};
   var localsSentinel = {};
   override('readFile', function (filename, encoding) {
@@ -128,7 +130,7 @@ test('compileFileAsync - with tr.render(src, options, locals) => output', functi
     assert(out.fn(localsSentinel) === 'example output');
   });
 });
-test('compileFileAsync - without tr.compile, tr.compileAsync, tr.compileFile, tr.compileFileAsync, tr.render or tr.renderFile', function (override) {
+test('without any of the above', function (override) {
   override('readFile', function (filename) {
     assert(filename === 'example-input.txt');
     return Promise.resolve('example input');
@@ -144,4 +146,6 @@ test('compileFileAsync - without tr.compile, tr.compileAsync, tr.compileFile, tr
   }, function (err) {
     if (!(/does not support/.test(err.message))) throw err;
   });
+});
+
 });

--- a/test/compile-file-client-async.js
+++ b/test/compile-file-client-async.js
@@ -5,7 +5,9 @@ var Promise = require('promise');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compileFileClientAsync - with tr.compileFileClientAsync(filename, options) => Promise(fn)', function (override) {
+test('compileFileClientAsync', function () {
+
+test('with tr.compileFileClientAsync(filename, options) => Promise(fn)', function (override) {
   var optionsSentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -24,7 +26,7 @@ test('compileFileClientAsync - with tr.compileFileClientAsync(filename, options)
   });
   assert(tr.compileFileClientAsync('example-input.txt', optionsSentinel) === normalizedSentinel);
 });
-test('compileFileClientAsync - with tr.compileFileClient(filename, options) => fn', function (override) {
+test('with tr.compileFileClient(filename, options) => fn', function (override) {
   var optionsSentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -93,7 +95,7 @@ test('compileFileClient - with tr.compileClient(filename, options) => fn', funct
   assert(tr.compileFileClientAsync('example-input.txt', optionsSentinel) === normalizedSentinel);
 });
 
-test('compileFileClientAsync - without tr.compileClient, tr.compileClientAsync, tr.compileFileClient or tr.compileFileClientAsync', function (override) {
+test('without any of the above', function (override) {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -105,4 +107,6 @@ test('compileFileClientAsync - without tr.compileClient, tr.compileClientAsync, 
   }, function (err) {
     if (!/does not support/.test(err.message)) throw err;
   });
+});
+
 });

--- a/test/compile-file-client.js
+++ b/test/compile-file-client.js
@@ -5,7 +5,9 @@ var Promise = require('promise');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compileFileClient - with tr.compileFileClient(filename, options) => fn', function (override) {
+test('compileFileClient', function () {
+
+test('with tr.compileFileClient(filename, options) => fn', function (override) {
   var optionsSentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -25,7 +27,7 @@ test('compileFileClient - with tr.compileFileClient(filename, options) => fn', f
   assert(tr.compileFileClient('example-input.txt', optionsSentinel) === normalizedSentinel);
 });
 
-test('compileFileClient - with tr.compileClient(filename, options) => fn', function (override) {
+test('with tr.compileClient(filename, options) => fn', function (override) {
   var optionsSentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -50,7 +52,7 @@ test('compileFileClient - with tr.compileClient(filename, options) => fn', funct
   assert(tr.compileFileClient('example-input.txt', optionsSentinel) === normalizedSentinel);
 });
 
-test('compileFileClient - without tr.compileClient or tr.compileFileClient', function () {
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -69,4 +71,6 @@ test('compileFileClient - without tr.compileClient or tr.compileFileClient', fun
   assert.throws(function () {
     tr.compileFileClient('example-input.txt', {});
   }, /does not support compiling for the client/);
+});
+
 });

--- a/test/compile-file.js
+++ b/test/compile-file.js
@@ -4,7 +4,9 @@ var assert = require('assert');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compileFile - with tr.compileFile(src, options) => fn', function (override) {
+test('compileFile', function () {
+
+test('with tr.compileFile(src, options) => fn', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -23,7 +25,7 @@ test('compileFile - with tr.compileFile(src, options) => fn', function (override
   });
   assert(tr.compileFile('example input', sentinel) === normalizedSentinel);
 });
-test('compileFile - with tr.compile(src, options) => fn', function (override) {
+test('with tr.compile(src, options) => fn', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -46,7 +48,7 @@ test('compileFile - with tr.compile(src, options) => fn', function (override) {
   });
   assert(tr.compileFile('example-input.txt', sentinel) === normalizedSentinel);
 });
-test('compileFile - with tr.renderFile(src, options, locals) => output', function (override) {
+test('with tr.renderFile(src, options, locals) => output', function (override) {
   var sentinel = {};
   var localsSentinel = {};
   var tr = createTransformer({
@@ -61,7 +63,7 @@ test('compileFile - with tr.renderFile(src, options, locals) => output', functio
   });
   assert(tr.compileFile('example-input.txt', sentinel).fn(localsSentinel) === 'example output');
 });
-test('compileFile - with tr.render(src, options, locals) => output', function (override) {
+test('with tr.render(src, options, locals) => output', function (override) {
   var sentinel = {};
   var localsSentinel = {};
   override('readFileSync', function (filename) {
@@ -80,7 +82,7 @@ test('compileFile - with tr.render(src, options, locals) => output', function (o
   });
   assert(tr.compileFile('example-input.txt', sentinel).fn(localsSentinel) === 'example output');
 });
-test('compileFile - without tr.compile, tr.compileFile, tr.render, or tr.renderFile', function () {
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -90,4 +92,6 @@ test('compileFile - without tr.compile, tr.compileFile, tr.render, or tr.renderF
   assert.throws(function () {
     tr.compileFile('example input', {});
   }, /does not support synchronous compilation/);
+});
+
 });

--- a/test/compile.js
+++ b/test/compile.js
@@ -4,7 +4,9 @@ var assert = require('assert');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('compile - with tr.compile(src, options) => fn', function (override) {
+test('compile', function () {
+
+test('with tr.compile(src, options) => fn', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -23,7 +25,19 @@ test('compile - with tr.compile(src, options) => fn', function (override) {
   });
   assert(tr.compile('example input', sentinel) === normalizedSentinel);
 });
-test('compile - without tr.compile', function () {
+
+test('with tr.render(src, options, locals) => output', function () {
+  var tr = createTransformer({
+    name: 'test',
+    outputFormat: 'html',
+    render: function (str, options, locals) {
+      assert(str === 'example input');
+      return locals.name;
+    }
+  });
+  assert.equal(tr.compile('example input').fn({name: 'hola'}), 'hola');
+});
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -53,14 +67,4 @@ test('compile - without tr.compile', function () {
   }, /does not support compilation/);
 });
 
-test('compile - without tr.compile, but with tr.render => fn', function () {
-  var tr = createTransformer({
-    name: 'test',
-    outputFormat: 'html',
-    render: function (str, options, locals) {
-      assert(str === 'example input');
-      return locals.name;
-    }
-  });
-  assert.equal(tr.compile('example input').fn({name: 'hola'}), 'hola');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -4,23 +4,25 @@ var assert = require('assert');
 var test = require('testit');
 var createTransformer = require('../');
 
-test('constructor - throws if `tr` is not an object', function () {
+test('constructor', function () {
+test('throws if `tr` is not an object', function () {
   assert.throws(function () {
     createTransformer(false);
   }, /Transformer must be an object/);
 });
-test('constructor - throws if `tr` does not have a name', function () {
+test('throws if `tr` does not have a name', function () {
   assert.throws(function () {
     createTransformer({});
   }, /Transformer must have a name/);
 });
-test('constructor - throws if `tr` does not have any methods', function () {
+test('throws if `tr` does not have any methods', function () {
   assert.throws(function () {
     createTransformer({name: 'test', outputFormat: 'html'});
   }, /Transformer must implement at least one of the potential methods/);
 });
-test('constructor - passes for a well formed transformer', function () {
+test('passes for a well formed transformer', function () {
   createTransformer({name: 'test', outputFormat: 'html', render: function () { return '<br/>'; }});
+});
 });
 
 require('./compile');

--- a/test/input-formats.js
+++ b/test/input-formats.js
@@ -4,7 +4,8 @@ var assert = require('assert');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('inputFormats - with tr.inputFormats', function (override) {
+test('inputFormats', function () {
+test('with tr.inputFormats', function (override) {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -19,7 +20,7 @@ test('inputFormats - with tr.inputFormats', function (override) {
   assert.deepEqual(tr.inputFormats, ['html', 'htm']);
 });
 
-test('inputFormats - without tr.inputFormats', function (override) {
+test('without any of the above', function (override) {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -28,4 +29,5 @@ test('inputFormats - without tr.inputFormats', function (override) {
     }
   });
   assert.deepEqual(tr.inputFormats, ['test']);
+});
 });

--- a/test/output-format.js
+++ b/test/output-format.js
@@ -4,7 +4,9 @@ var assert = require('assert');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('outputFormat - preserves tr.outputFormat', function () {
+test('outputFormat', function () {
+
+test('preserves tr.outputFormat', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'css',
@@ -14,7 +16,7 @@ test('outputFormat - preserves tr.outputFormat', function () {
   });
   assert.equal(tr.outputFormat, 'css');
 });
-test('outputFormat - throws without tr.outputFormat', function () {
+test('throws without tr.outputFormat', function () {
   assert.throws(function () {
     createTransformer({
       name: 'test',
@@ -23,4 +25,6 @@ test('outputFormat - throws without tr.outputFormat', function () {
       }
     });
   }, /Transformer must have an output format/);
+});
+
 });

--- a/test/render-async.js
+++ b/test/render-async.js
@@ -5,7 +5,9 @@ var Promise = require('promise');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('renderAsync - with tr.renderAsync(src, options) => str', function (override) {
+test('renderAsync', function () {
+
+test('with tr.renderAsync(src, options) => str', function (override) {
   var sentinel = {};
   var localSentinel = {};
   var fnSentinel = {};
@@ -27,7 +29,7 @@ test('renderAsync - with tr.renderAsync(src, options) => str', function (overrid
   });
   assert(tr.renderAsync('example input', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('renderAsync - with tr.render(src, options) => str', function (override) {
+test('with tr.render(src, options) => str', function (override) {
   var sentinel = {};
   var localSentinel = {};
   var fnSentinel = {};
@@ -49,7 +51,7 @@ test('renderAsync - with tr.render(src, options) => str', function (override) {
   });
   assert(tr.renderAsync('example input', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('renderAsync - with tr.compileAsync(src, options) => fn', function (override) {
+test('with tr.compileAsync(src, options) => fn', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -79,7 +81,7 @@ test('renderAsync - with tr.compileAsync(src, options) => fn', function (overrid
   };
   assert(tr.renderAsync('example input', sentinel, cbSentinel) === normalizedSentinel);
 });
-test('renderAsync - with tr.compile(src, options) => fn', function (override) {
+test('with tr.compile(src, options) => fn', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -126,7 +128,7 @@ test('renderAsync(src, options, locals) - with tr.compile(src, options) => fn', 
       assert.equal( res.body, nameSentinel)
     })
 });
-test('renderAsync - without tr.render', function () {
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -154,4 +156,6 @@ test('renderAsync - without tr.render', function () {
     }
   });
   return Promise.all([a, b]);
+});
+
 });

--- a/test/render.js
+++ b/test/render.js
@@ -5,7 +5,9 @@ var Promise = require('promise');
 var test = require('./test');
 var createTransformer = require('../');
 
-test('render - with tr.render(src, options) => str', function (override) {
+test('render', function () {
+
+test('with tr.render(src, options) => str', function (override) {
   var sentinel = {};
   var localSentinel = {};
   var fnSentinel = {};
@@ -25,7 +27,7 @@ test('render - with tr.render(src, options) => str', function (override) {
   });
   assert(tr.render('example input', sentinel) === normalizedSentinel);
 });
-test('render - with tr.compile(src, options) => fn', function (override) {
+test('with tr.compile(src, options) => fn', function (override) {
   var sentinel = {};
   var fnSentinel = {};
   var normalizedSentinel = {};
@@ -70,7 +72,7 @@ test('render(src, options, locals) - with tr.compile(src, options) => fn', funct
                         , { name: nameSentinel }).body
               , nameSentinel);
 });
-test('render - without tr.render', function () {
+test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',
     outputFormat: 'html',
@@ -113,4 +115,6 @@ test('render - without tr.render', function () {
   assert.throws(function () {
     tr.render('example input', {});
   }, /does not support rendering synchronously/);
+});
+
 });


### PR DESCRIPTION
From:

     ✓ constructor - throws if `tr` is not an object (5ms)
     ✓ constructor - throws if `tr` does not have a name (1ms)
     ✓ constructor - throws if `tr` does not have an output format (1ms)
     ✓ constructor - throws if `tr` does not have any methods (0ms)
     ✓ constructor - passes for a well formed transformer (0ms)
     ✓ compile - with tr.compile(src, options) => fn (1ms)
     ✓ compile - without tr.compile (1ms)
     ✓ compile - without tr.compile, but with tr.render => fn (1ms)

to:

     • constructor
       ✓ throws if `tr` is not an object (2ms)
       ✓ throws if `tr` does not have a name (1ms)
       ✓ throws if `tr` does not have an output format (0ms)
       ✓ throws if `tr` does not have any methods (0ms)
       ✓ passes for a well formed transformer (0ms)
     • compile
       ✓ with tr.compile(src, options) => fn (0ms)
       ✓ with tr.render(src, options, locals) => body (1ms)
       ✓ without any of the above (1ms)