### PR TITLE
Document `compile*` api and format readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <p align="center"><img src="https://cdn.rawgit.com/jstransformers/jstransformer/2bb6dc6c410e8683a17a4af5f1b73bcbee95aada/logo.svg" width="300px" height="299px" /></p>
 <h1 align="center">JSTransformer</h1>
 <p align="center">Normalize the API of any jstransformer</p>
@@ -47,6 +48,7 @@ Compile a given string and return an object.
 **Params**
 - `<str>` **{String}** string to compile
 - `[options]` **{Object}** optional options to pass to
+- `returns` **{Object}**
 
 **Requires the underlying transform to implement one of following methods**
 - `.compile`
@@ -89,7 +91,7 @@ Compile a string from a given `filepath` synchronously.
 **Params**
 - `<filepath>` **{String}** path to file to compile
 - `[options]` **{Object}** optional options to pass to
-- `returns` **{Promise}**
+- `returns` **{Object}**
 
 **Requires the underlying transform to implement one of following methods**
 - `.compileFile`
@@ -100,7 +102,7 @@ Compile a string from a given `filepath` synchronously.
 **Example**
 
 ```js
-transformer.compileFile(filepath, options)
+transformer.compileFile(filepath, options);
 //=> {fn: Function, dependencies: Array.<String>}
 ```
 
@@ -150,6 +152,7 @@ Render a given string and return an object.
 - `<str>` **{String}** string to render
 - `[options]` **{Object}** optional options to pass to
 - `[locals]` **{Object}** template context, also known as locals
+- `returns` **{Object}**
 
 **Requires the underlying transform to implement one of following methods**
 - `.compile`
@@ -195,7 +198,7 @@ Render a string from a given `filepath` synchronously.
 - `<filepath>` **{String}** path to file to compile
 - `[options]` **{Object}** optional options to pass to
 - `[locals]` **{Object}** template context, also known as locals
-- `returns` **{Promise}**
+- `returns` **{Object}**
 
 **Requires the underlying transform to implement one of following methods**
 - `.renderFile`
@@ -206,7 +209,7 @@ Render a string from a given `filepath` synchronously.
 **Example**
 
 ```js
-transformer.renderFile(filepath, options, locals)
+transformer.renderFile(filepath, options, locals);
 //=> {fn: Function, dependencies: Array.<String>}
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@
 <a href="https://coveralls.io/r/jstransformers/jstransformer?branch=master"><img src="https://img.shields.io/coveralls/jstransformers/jstransformer/master.svg" alt="Coverage Status"></a>
 <a href="https://www.npmjs.org/package/jstransformer"><img src="https://img.shields.io/npm/v/jstransformer.svg" alt="NPM version"></a></p>
 
+
 ## Installation
 
-    npm install jstransformer
+```
+npm install jstransformer --save
+```
 
 ## Usage
 
@@ -20,17 +23,118 @@ var marked = transformer(require('jstransformer-marked'));
 
 var options = {};
 var res = marked.render('Some **markdown**', options);
-// => {body: 'Some <strong>markdown</strong>', dependencies: []}
+//=> {body: 'Some <strong>markdown</strong>', dependencies: []}
 ```
 
 This gives the same API regardless of the jstransformer passed in.
 
 ## API
+A transformer, once normalised using this module, will implement the following methods. Note that if the underlying transformer cannot be used to implement the functionality, it may ultimately just throw an error.
 
-A transformer, once normalised using this module, will implement the following methods.  Note that if the underlying transformer cannot be used to implement the functionality, it may ultimately just throw an error.
+
+### Returned object from `.compile*`
+```js
+{fn: Function, dependencies: Array.<String>}
+```
+
+ - `fn` represents the render function, which also accept `locals`
+ - `dependencies` is an array of files that were read in as part of the compile process (or an empty array if there were no dependencies)
+
+
+### .compile
+Compile a given string and return an object.
+
+**Params**
+- `<str>` **{String}** string to compile
+- `[options]` **{Object}** optional options to pass to
+
+**Requires the underlying transform to implement one of following methods**
+- `.compile`
+- `.render`
+
+**Example**
+
+```js
+transformer.compile(str, options);
+//=> {fn: Function, dependencies: Array.<String>}
+```
+
+
+### .compileAsync
+Compile a string asynchronously.
+
+**Params**
+- `<str>` **{String}** string to compile
+- `[options]` **{Object}** optional options to pass to
+- `[callback]` **{Function}** if not given, returns Promise
+- `returns` **{Promise}**
+
+**Requires the underlying transform to implement one of following methods**
+- `.compileAsync`
+- `.compile`
+- `.render`
+
+**Example**
+
+```js
+transformer.compileAsync(str, options).then(function (res) {
+  //=> {fn: Function, dependencies: Array.<String>}
+});
+```
+
+
+### .compileFile
+Compile a string from a given `filepath` synchronously.
+
+**Params**
+- `<filepath>` **{String}** path to file to compile
+- `[options]` **{Object}** optional options to pass to
+- `returns` **{Promise}**
+
+**Requires the underlying transform to implement one of following methods**
+- `.compileFile`
+- `.compile`
+- `.renderFile`
+- `.render`
+
+**Example**
+
+```js
+transformer.compileFile(filepath, options)
+//=> {fn: Function, dependencies: Array.<String>}
+```
+
+
+### .compileFileAsync
+Compile a string from `filepath` asynchronously.
+
+**Params**
+- `<filepath>` **{String}** path to file to compile
+- `[options]` **{Object}** optional options to pass to
+- `[callback]` **{Function}** if not given, returns Promise
+- `returns` **{Promise}**
+
+**Requires the underlying transform to implement one of following methods**
+- `.compileFileAsync`
+- `.compileFile`
+- `.compileAsync`
+- `.compile`
+- `.renderFile`
+- `.render`
+
+**Example**
+
+```js
+transformer.compileFileAsync(filepath, options).then(function (res) {
+  //=> {fn: Function, dependencies: Array.<String>}
+});
+```
+
+
+***
+
 
 ### Returned object from `.render*`
-
 ```js
 {body: String, dependencies: Array.<String>}
 ```
@@ -38,76 +142,130 @@ A transformer, once normalised using this module, will implement the following m
  - `body` represents the result as a string
  - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
 
-### `.render`
+
+### .render
+Render a given string and return an object.
+
+**Params**
+- `<str>` **{String}** string to render
+- `[options]` **{Object}** optional options to pass to
+- `[locals]` **{Object}** template context, also known as locals
+
+**Requires the underlying transform to implement one of following methods**
+- `.compile`
+- `.render`
+
+**Example**
 
 ```js
 transformer.render(str, options, locals);
-=> {body: String, dependencies: Array.<String>}
+//=> {body: String, dependencies: Array.<String>}
 ```
 
-_requires the underlying transform to implement `.render` or `.compile`_
 
-Transform a string and return an object.
+### .renderAsync
+Render a string asynchronously.
 
-### `.renderAsync`
+**Params**
+- `<str>` **{String}** string to compile
+- `[options]` **{Object}** optional options to pass to
+- `[locals]` **{Object}** template context, also known as locals
+- `[callback]` **{Function}** if not given, returns Promise
+- `returns` **{Promise}**
+
+**Requires the underlying transform to implement one of following methods**
+- `.renderAsync`
+- `.render`
+- `.compileAsync`
+- `.compile`
+
+**Example**
 
 ```js
-transformer.renderAsync(str[, options], locals, callback);
+transformer.renderAsync(str, options, locals).then(function (res) {
+  //=> {fn: Function, dependencies: Array.<String>}
+});
 ```
+
+
+### .renderFile
+Render a string from a given `filepath` synchronously.
+
+**Params**
+- `<filepath>` **{String}** path to file to compile
+- `[options]` **{Object}** optional options to pass to
+- `[locals]` **{Object}** template context, also known as locals
+- `returns` **{Promise}**
+
+**Requires the underlying transform to implement one of following methods**
+- `.renderFile`
+- `.render`
+- `.compileFile`
+- `.compile`
+
+**Example**
 
 ```js
-transformer.renderAsync(str[, options], locals);
-=> Promise({body: String, dependencies: Array.<String>})
+transformer.renderFile(filepath, options, locals)
+//=> {fn: Function, dependencies: Array.<String>}
 ```
 
-_requires the underlying transform to implement `.renderAsync` or `.render`_
 
-Transform a string asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
+### .renderFileAsync
+Compile a string from `filepath` asynchronously.
 
-### `.renderFile`
+**Params**
+- `<filepath>` **{String}** path to file to compile
+- `[options]` **{Object}** optional options to pass to
+- `[locals]` **{Object}** template context, also known as locals
+- `[callback]` **{Function}** if not given, returns Promise
+- `returns` **{Promise}**
+
+**Requires the underlying transform to implement one of following methods**
+- `.renderFileAsync`
+- `.renderFile`
+- `.render`
+- `.compileAsync`
+- `.compileFile`
+- `.compile`
+
+**Example**
 
 ```js
-transformer.renderFile(filename, options, locals)
-=> {body: String, dependencies: Array.<String>}
+transformer.renderFileAsync(filepath, options, locals).then(function (res) {
+  //=> {fn: Function, dependencies: Array.<String>}
+});
 ```
 
-_requires the underlying transform to implement `.renderFile`, `.render`, `.compileFile`, or `.compile`_
 
-Transform a file and return an object.
+***
 
-### `.renderFileAsync`
 
-```js
-transformer.renderFileAsync(filename[, options], locals, callback);
-```
-
-```js
-transformer.renderFileAsync(filename[, options], locals);
-=> Promise({body: String, dependencies: Array.<String>})
-```
-
-_requires the underlying transform to implement `.renderFileAsync`, `.renderFile`, `.renderAsync`, `.render`, `.compileFileAsync`, `.compileFile`, `.compileAsync`, or `.compileFile`_
-
-Transform a file asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
-
-### `.inputFormats`
-
-```js
-var formats = transformer.inputFormats;
-=> ['md', 'markdown']
-```
+### .inputFormats
 
 Returns an array of strings representing potential input formats for the transform. If not provided directly by the transform, results in an array containing the name of the transform.
 
-### `.outputFormat`
+**Example**
 
 ```js
-var md = require('jstransformer')(require('jstransformer-markdown'))
-var outputFormat = md.outputFormat
-=> 'html'
+var hbs = require('jstransformer')(require('jstransformer-handlebars'))
+var formats = hbs.inputFormats;
+//=> ['hbs', 'handlebars']
 ```
 
+
+### .outputFormat
+
 Returns a string representing the default output format the transform would be expected to return when calling `.render()`.
+
+**Example**
+
+```js
+var hbs = require('jstransformer')(require('jstransformer-handlebars'))
+var formats = hbs.outputFormat;
+//=> 'html'
+```
+
 
 ## License
 


### PR DESCRIPTION
It not includes `*client*` methods, cuz i dont know exactly what's the idea behind them.
Also normalize `render*` documentation.
