### PR TITLE
Fix browser compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,13 @@ tr.normalizeFn = normalizeFn;
 tr.normalizeFnAsync = normalizeFnAsync;
 tr.normalize = normalize;
 tr.normalizeAsync = normalizeAsync;
-tr.readFile = Promise.denodeify(fs.readFile);
-tr.readFileSync = fs.readFileSync;
+if (fs.readFile) {
+  tr.readFile = Promise.denodeify(fs.readFile);
+  tr.readFileSync = fs.readFileSync;
+} else {
+  tr.readFile = function () { throw new Error('fs.readFile unsupported'); };
+  tr.readFileSync = function () { throw new Error('fs.readFileSync unsupported'); };
+}
 
 function normalizeFn(result) {
   if (typeof result === 'function') {


### PR DESCRIPTION
This makes jstransformer work when built using Browserify and used in the browser.

The caveat, of course, is that things that rely on `fs.readFile` and `fs.readFileSync` will fail... if you're using jstransformer in the browser, you won't be using that, of course.