### PR TITLE
Expand API Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ A transformer, once normalised using this module, will implement the following m
 ```
 
  - `body` represents the result as a string
- - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
+ - `dependencies` is an array of file names that were read in as part of the render process (or an empty array if there were no dependencies)
 
 #### `.render`
 
@@ -100,8 +100,8 @@ Transform a file asynchronously. If a callback is provided, it is called as `cal
 {fn: Function, dependencies: Array.<String>}
 ```
 
- - `fn` represents the result as a string
- - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
+ - `fn` is a function that takes a locals object and returns the rendered template as a string.
+ - `dependencies` is an array of file names that were read in as part of the compilation process (or an empty array if there were no dependencies)
 
 #### `.compile`
 
@@ -164,7 +164,7 @@ Compile a file asynchronously. If a callback is provided, it is called as `callb
 ```
 
  - `body` is a `.toString`ed function that can be used on the client side.
- - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
+ - `dependencies` is an array of file names that were read in as part of the compilation process (or an empty array if there were no dependencies)
 
 #### `.compileClient`
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,67 @@ _requires the underlying transform to implement `.renderFileAsync`, `.renderFile
 
 Transform a file asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 
+### Returned object from `.compile*`
+
+```js
+{fn: Function, dependencies: Array.<String>}
+```
+
+ - `fn` represents the result as a string
+ - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
+
+### `.compile`
+
+```js
+transformer.compile(str[, options]);
+=> {fn: Function, dependencies: Array.<String>}
+```
+
+_requires the underlying transform to implement `.compile` or `.render`_
+
+Compile a string and return an object.
+
+### `.compileAsync`
+
+```js
+transformer.compileAsync(str[, options], callback);
+```
+
+```js
+transformer.compileAsync(str[, options]);
+=> Promise({fn: Function, dependencies: Array.<String>})
+```
+
+_requires the underlying transform to implement `.compileAsync`, `.compile` or `.render`_
+
+Compile a string asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
+
+### `.compileFile`
+
+```js
+transformer.compileFile(filename[, options])
+=> {fn: Function, dependencies: Array.<String>}
+```
+
+_requires the underlying transform to implement `.compileFile`, `.compile`, `.renderFile`, or `.render`_
+
+Compile a file and return an object.
+
+### `.compileFileAsync`
+
+```js
+transformer.compileFileAsync(filename[, options], callback);
+```
+
+```js
+transformer.compileFileAsync(filename[, options]);
+=> Promise({fn: Function, dependencies: Array.<String>})
+```
+
+_requires the underlying transform to implement `.compileFileAsync`, `.compileFile`, `.compileAsync`, `.compile`, `.renderFileAsync`, `.renderFile`, or `.render`_
+
+Compile a file asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
+
 ### `.inputFormats`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ var outputFormat = md.outputFormat
 
 Returns a string representing the default output format the transform would be expected to return when calling `.render()`.
 
+### `.can`
+
+```js
+var md = require('jstransformer')(require('jstransformer-markdown'))
+md.can('render');
+=> true
+```
+
+Takes a method name as a string and returns a boolean value indicating whether the normalised transform implements this method.
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ transformer.renderAsync(str[, options], locals);
 => Promise({body: String, dependencies: Array.<String>})
 ```
 
-_requires the underlying transform to implement `.renderAsync` or `.render`_
+_requires the underlying transform to implement `.renderAsync`, `.render`, `.compile`, or `.compileAsync`_
 
 Transform a string asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 
@@ -86,7 +86,7 @@ transformer.renderFileAsync(filename[, options], locals);
 => Promise({body: String, dependencies: Array.<String>})
 ```
 
-_requires the underlying transform to implement `.renderFileAsync`, `.renderFile`, `.renderAsync`, `.render`, `.compileFileAsync`, `.compileFile`, `.compileAsync`, or `.compileFile`_
+_requires the underlying transform to implement `.renderFileAsync`, `.renderFile`, `.renderAsync`, `.render`, `.compileFileAsync`, `.compileFile`, `.compileAsync`, or `.compile`_
 
 Transform a file asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,69 @@ _requires the underlying transform to implement `.compileFileAsync`, `.compileFi
 
 Compile a file asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 
+### `.compileClient*`
+
+#### Returned object from `.compileClient*`
+
+```js
+{body: String, dependencies: Array.<String>}
+```
+
+ - `body` is a `.toString`ed function that can be used on the client side.
+ - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
+
+#### `.compileClient`
+
+```js
+transformer.compileClient(str[, options]);
+=> {body: String, dependencies: Array.<String>}
+```
+
+_requires the underlying transform to implement `.compileClient`_
+
+Compile a string for client-side use and return an object.
+
+#### `.compileClientAsync`
+
+```js
+transformer.compileClientAsync(str[, options], callback);
+```
+
+```js
+transformer.compileClientAsync(str[, options]);
+=> Promise({body: String, dependencies: Array.<String>})
+```
+
+_requires the underlying transform to implement `.compileClientAsync` or `.compileClient`_
+
+Compile a string for client-side use asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
+
+#### `.compileFileClient`
+
+```js
+transformer.compileFileClient(filename[, options])
+=> {body: String, dependencies: Array.<String>}
+```
+
+_requires the underlying transform to implement `.compileFileClient` or `.compileClient`_
+
+Compile a file for client-side use and return an object.
+
+#### `.compileFileClientAsync`
+
+```js
+transformer.compileFileClientAsync(filename[, options], callback);
+```
+
+```js
+transformer.compileFileClientAsync(filename[, options]);
+=> Promise({body: String, dependencies: Array.<String>})
+```
+
+_requires the underlying transform to implement `.compileFileClientAsync`, `.compileFileClient`, `.compileClientAsync`, or `.compileClient`_
+
+Compile a file for client-side use asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
+
 ### `.inputFormats`
 
 ```js

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ This gives the same API regardless of the jstransformer passed in.
 
 A transformer, once normalised using this module, will implement the following methods.  Note that if the underlying transformer cannot be used to implement the functionality, it may ultimately just throw an error.
 
-### Returned object from `.render*`
+### `.render*`
+
+#### Returned object from `.render*`
 
 ```js
 {body: String, dependencies: Array.<String>}
@@ -38,7 +40,7 @@ A transformer, once normalised using this module, will implement the following m
  - `body` represents the result as a string
  - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
 
-### `.render`
+#### `.render`
 
 ```js
 transformer.render(str, options, locals);
@@ -49,7 +51,7 @@ _requires the underlying transform to implement `.render` or `.compile`_
 
 Transform a string and return an object.
 
-### `.renderAsync`
+#### `.renderAsync`
 
 ```js
 transformer.renderAsync(str[, options], locals, callback);
@@ -64,7 +66,7 @@ _requires the underlying transform to implement `.renderAsync`, `.render`, `.com
 
 Transform a string asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 
-### `.renderFile`
+#### `.renderFile`
 
 ```js
 transformer.renderFile(filename, options, locals)
@@ -75,7 +77,7 @@ _requires the underlying transform to implement `.renderFile`, `.render`, `.comp
 
 Transform a file and return an object.
 
-### `.renderFileAsync`
+#### `.renderFileAsync`
 
 ```js
 transformer.renderFileAsync(filename[, options], locals, callback);
@@ -90,7 +92,9 @@ _requires the underlying transform to implement `.renderFileAsync`, `.renderFile
 
 Transform a file asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 
-### Returned object from `.compile*`
+### `.compile*`
+
+#### Returned object from `.compile*`
 
 ```js
 {fn: Function, dependencies: Array.<String>}
@@ -99,7 +103,7 @@ Transform a file asynchronously. If a callback is provided, it is called as `cal
  - `fn` represents the result as a string
  - `dependencies` is an array of files that were read in as part of the render process (or an empty array if there were no dependencies)
 
-### `.compile`
+#### `.compile`
 
 ```js
 transformer.compile(str[, options]);
@@ -110,7 +114,7 @@ _requires the underlying transform to implement `.compile` or `.render`_
 
 Compile a string and return an object.
 
-### `.compileAsync`
+#### `.compileAsync`
 
 ```js
 transformer.compileAsync(str[, options], callback);
@@ -125,7 +129,7 @@ _requires the underlying transform to implement `.compileAsync`, `.compile` or `
 
 Compile a string asynchronously. If a callback is provided, it is called as `callback(err, data)`, otherwise a Promise is returned.
 
-### `.compileFile`
+#### `.compileFile`
 
 ```js
 transformer.compileFile(filename[, options])
@@ -136,7 +140,7 @@ _requires the underlying transform to implement `.compileFile`, `.compile`, `.re
 
 Compile a file and return an object.
 
-### `.compileFileAsync`
+#### `.compileFileAsync`
 
 ```js
 transformer.compileFileAsync(filename[, options], callback);


### PR DESCRIPTION
Added API docs for `.compile*`, `.compileClient*`, and `.can`. Resolves #26.

Also fixed a few errors in the existing fallback lists.

I reordered the headings in an attempt to make things clearer and a bit more organized. Perhaps a table of contents should be added: https://github.com/thlorenz/doctoc.

I realize this is quite a few commits in one PR, let me know if you want me to squash, reorder, rebase, etc.