### PR TITLE
When calling compileAsync(), fallback to renderAsync

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,6 +159,12 @@ Transformer.prototype.compile = function (str, options) {
 };
 Transformer.prototype.compileAsync = function (str, options, cb) {
   if (!this.can('compileAsync')) { // compileFile* || renderFile* || renderAsync || compile*Client*
+    if (this.can('renderAsync')) {
+      var customCompile = function (str, options) {
+        return this.renderAsync(str, options);
+      }
+      return tr.normalizeFnAsync(customCompile, cb);
+    }
     return Promise.reject(new Error('The Transform "' + this.name + '" does not support compiling plain strings')).nodeify(cb);
   }
   if (this._hasMethod('compileAsync')) {

--- a/test/compile-async.js
+++ b/test/compile-async.js
@@ -61,6 +61,22 @@ test('with tr.render(str, options, locals) => output', function () {
     assert(out.fn(localsSentinel) === 'example output');
   });
 });
+test('with tr.renderAsync(str, options, locals) => Promise(fn)', function () {
+  var sentinel = {};
+  var localsSentinel = {};
+  var tr = createTransformer({
+    name: 'test',
+    outputFormat: 'html',
+    renderAsync: function (str, options, locals) {
+      return new Promise(function (resolve, reject) {
+        resolve('example output')
+      })
+    }
+  });
+  return tr.compileAsync('example input', sentinel).then(function (out) {
+    assert(out.fn(localsSentinel) === 'example output');
+  });
+});
 test('without any of the above', function () {
   var tr = createTransformer({
     name: 'test',


### PR DESCRIPTION
When calling compileAsync(), we should fallback to renderAsync(). Not sure if this is done right.