### PR TITLE
Change order of fallbacks for renderFileAsync

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,16 +344,15 @@ Transformer.prototype.renderFileAsync = function (filename, options, locals, cb)
     return tr.normalizeAsync(this._tr.renderFileAsync(filename, options, locals), cb);
   } else if (this._hasMethod('renderFile')) {
     return tr.normalizeAsync(this._tr.renderFile(filename, options, locals), cb);
-  } else if (this._hasMethod('compile') || this._hasMethod('compileAsync')
-             || this._hasMethod('compileFile') || this._hasMethod('compileFileAsync')) {
-    return tr.normalizeAsync(this.compileFileAsync(filename, options).then(function (compiled) {
-      return {body: compiled.fn(locals || options), dependencies: compiled.dependencies};
-    }), cb);
-  } else { // render || renderAsync
+  } else if (this._hasMethod('render') || this._hasMethod('renderAsync')) { // render || renderAsync
     if (!options) options = {};
     if (options.filename === undefined) options.filename = filename;
     return tr.normalizeAsync(tr.readFile(filename, 'utf8').then(function (str) {
       return this.renderAsync(str, options, locals);
     }.bind(this)), cb);
-  }
+  } else {
+    return tr.normalizeAsync(this.compileFileAsync(filename, options).then(function (compiled) {
+    return {body: compiled.fn(locals || options), dependencies: compiled.dependencies};
+    }), cb);
+    }
 };


### PR DESCRIPTION
This PR can be considered a question in the form of a PR. Sometimes just plain code conveys a question better. If the answer to my question is 'yes' than the PR can be merged.

The documentation gives the impression that the fallback for a method
follows a certain order. For renderFileAsync that order should then be

* `.renderFileAsync`
* `.renderFile`
* `.renderAsync`
* `.render`
* `.compileFileAsync`
* `.compileFile`
* `.compileAsync`
* `.compile`

This commit makes the code follow that order.

Am I correct in assuming that the fallback should be in the order described in the documentation?